### PR TITLE
add additional imports for generating and verifying password

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -28,14 +28,6 @@ export default function objectionPasswordArgon2(configuration: Configuration = {
         return isArgonHash(str)
       }
 
-      /**
-       * Compares a password to an Argon2 hash
-       */
-      public static async verifyPassword(password: string, otherPassword: string): Promise<boolean> {
-        const hash = await Argon2.hash(password)
-        return Argon2.verify(hash, otherPassword)
-      }
-
       public async $beforeInsert(context: QueryContext) {
         await super.$beforeInsert(context)
 
@@ -99,7 +91,23 @@ export default function objectionPasswordArgon2(configuration: Configuration = {
   }
 }
 
-function isArgonHash(str: string) {
+export function isArgonHash(str: string) {
   const ARGON2_REGEXP = /^\$argon/
   return ARGON2_REGEXP.test(str)
+}
+
+/**
+ * Generates an Argon2 hash from a string
+ */
+export async function generatePasswordHash (password: string): Promise<string> {
+  const hash = Argon2.hash(password)
+  return hash
+}
+
+/**
+ * Compares a password to an Argon2 hash
+ */
+export async function verifyPassword (password: string, otherPassword: string): Promise<boolean> {
+  const hash = await Argon2.hash(password)
+  return Argon2.verify(hash, otherPassword)
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -16,7 +16,9 @@ const DEFAULT_OPTIONS: Options = {
   passwordField: 'password'
 }
 
-export default function objectionPasswordArgon2(configuration: Configuration = {}): Function {
+export default function objectionPasswordArgon2 (
+  configuration: Configuration = {}
+): Function {
   const options: Options = Object.assign({}, DEFAULT_OPTIONS, configuration)
 
   return (ModelClass: typeof Model) => {
@@ -24,25 +26,20 @@ export default function objectionPasswordArgon2(configuration: Configuration = {
       /**
        * Detect rehashing for avoiding undesired effects
        */
-      public static isArgonHash(str: string): boolean {
+      public static isArgonHash (str: string): boolean {
         return isArgonHash(str)
       }
 
-      /**
-       * Compares a password to an Argon2 hash
-       */
-      public static async verifyPassword(password: string, otherPassword: string): Promise<boolean> {
-        const hash = await Argon2.hash(password)
-        return Argon2.verify(hash, otherPassword)
-      }
-
-      public async $beforeInsert(context: QueryContext) {
+      public async $beforeInsert (context: QueryContext) {
         await super.$beforeInsert(context)
 
         return this.generateHash()
       }
 
-      public async $beforeUpdate(opt: ModelOptions, queryContext: QueryContext) {
+      public async $beforeUpdate (
+        opt: ModelOptions,
+        queryContext: QueryContext
+      ) {
         await super.$beforeUpdate(opt, queryContext)
 
         if (opt.patch && this.getPasswordHash() === undefined) {
@@ -55,7 +52,7 @@ export default function objectionPasswordArgon2(configuration: Configuration = {
       /**
        * Compares a password to an Argon2 hash
        */
-      public async verifyPassword(password: string): Promise<boolean> {
+      public async verifyPassword (password: string): Promise<boolean> {
         const hash = this.getPasswordHash()
 
         if (!hash) {
@@ -68,7 +65,7 @@ export default function objectionPasswordArgon2(configuration: Configuration = {
       /**
        * Generates an Argon2 hash
        */
-      private async generateHash() {
+      private async generateHash () {
         const password = this.getPasswordHash()
 
         if (password && password.length > 0) {
@@ -86,12 +83,12 @@ export default function objectionPasswordArgon2(configuration: Configuration = {
         }
       }
 
-      private setPasswordHash(hash: string) {
+      private setPasswordHash (hash: string) {
         // @ts-ignore
         this[options.passwordField] = hash
       }
 
-      private getPasswordHash(): string | null | undefined {
+      private getPasswordHash (): string | null | undefined {
         // @ts-ignore
         return this[options.passwordField]
       }
@@ -99,7 +96,26 @@ export default function objectionPasswordArgon2(configuration: Configuration = {
   }
 }
 
-function isArgonHash(str: string) {
+export function isArgonHash (str: string) {
   const ARGON2_REGEXP = /^\$argon/
   return ARGON2_REGEXP.test(str)
+}
+
+/**
+ * Generates an Argon2 hash from a string
+ */
+export async function generatePasswordHash (password: string): Promise<string> {
+  const hash = Argon2.hash(password)
+  return hash
+}
+
+/**
+ * Compares a password to an Argon2 hash
+ */
+export async function verifyPassword (
+  password: string,
+  otherPassword: string
+): Promise<boolean> {
+  const hash = await Argon2.hash(password)
+  return Argon2.verify(hash, otherPassword)
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,8 @@
-import ObjectionPassword from '../lib/index'
+import ObjectionPassword, {
+  generatePasswordHash,
+  isArgonHash,
+  verifyPassword
+} from '../lib/index'
 import Knex from 'knex'
 import { Model } from 'objection'
 
@@ -13,15 +17,15 @@ const knex = Knex({
 Model.knex(knex)
 
 class Dog extends ObjectionPassword()(Model) {
-  public static tableName = 'dog'
+  public static tableName = 'dog';
 
-  public readonly id?: number
-  public name?: string
-  public password?: string
+  public readonly id?: number;
+  public name?: string;
+  public password?: string;
 }
 
 beforeAll(async () => {
-  await knex.schema.createTable('dog', (table) => {
+  await knex.schema.createTable('dog', table => {
     table.increments()
     table.string('name')
     table.string('password')
@@ -47,33 +51,39 @@ test('creates new hash when updating password', async () => {
   const dog = await Dog.query().insert({ name: 'JJ', password: original })
   expect(await dog.verifyPassword(original)).toBe(true)
 
-  const updatedDog = await dog.$query().patchAndFetchById(dog.id!, { password: updated })
+  const updatedDog = await dog
+    .$query()
+    .patchAndFetchById(dog.id!, { password: updated })
   expect(await updatedDog.verifyPassword(updated)).toBe(true)
 })
 
-test('ignores hashing password field when patching a record where password isn\'t updated', async () => {
+test("ignores hashing password field when patching a record where password isn't updated", async () => {
   const dog = await Dog.query().insert({ name: 'JJ', password: 'Turtle123!' })
   const passwordHash = dog.password
 
-  const updatedDog = await dog.$query().patchAndFetchById(dog.id!, { name: 'Jumbo Jet' })
+  const updatedDog = await dog
+    .$query()
+    .patchAndFetchById(dog.id!, { name: 'Jumbo Jet' })
 
   expect(updatedDog.password).toEqual(passwordHash)
 })
 
 test('do not allow empty password', async () => {
   const password = ''
-  await expect(Dog.query().insert({ name: 'JJ', password })).rejects.toThrowError(/password must not be empty/)
+  await expect(
+    Dog.query().insert({ name: 'JJ', password })
+  ).rejects.toThrowError(/password must not be empty/)
 })
 
 test('allow empty password', async () => {
   class Mouse extends ObjectionPassword({ allowEmptyPassword: true })(Model) {
-    public static tableName = 'mouse'
+    public static tableName = 'mouse';
 
-    public name?: string
-    public password?: string
+    public name?: string;
+    public password?: string;
   }
 
-  await knex.schema.createTable('mouse', (table) => {
+  await knex.schema.createTable('mouse', table => {
     table.increments()
     table.string('name')
     table.string('password')
@@ -86,19 +96,22 @@ test('allow empty password', async () => {
 })
 
 test('throws an error when attempting to hash a argon2 hash', async () => {
-  const password = '$argon2i$v=19$m=4096,t=3,p=1$yqdvmjCHT1o+03hbpFg7HQ$Vg3+D9kW9+Nm0+ukCzKNWLb0h8iPQdTkD/HYHrxInhA'
-  await expect(Dog.query().insert({ name: 'JJ', password })).rejects.toThrowError('Argon2 tried to hash another Argon2 hash')
+  const password =
+    '$argon2i$v=19$m=4096,t=3,p=1$yqdvmjCHT1o+03hbpFg7HQ$Vg3+D9kW9+Nm0+ukCzKNWLb0h8iPQdTkD/HYHrxInhA'
+  await expect(
+    Dog.query().insert({ name: 'JJ', password })
+  ).rejects.toThrowError('Argon2 tried to hash another Argon2 hash')
 })
 
 test('can override default password field', async () => {
   class Cat extends ObjectionPassword({ passwordField: 'hash' })(Model) {
-    public static tableName = 'cat'
+    public static tableName = 'cat';
 
-    public name?: string
-    public hash?: string
+    public name?: string;
+    public hash?: string;
   }
 
-  await knex.schema.createTable('cat', (table) => {
+  await knex.schema.createTable('cat', table => {
     table.increments()
     table.string('name')
     table.string('hash')
@@ -112,7 +125,13 @@ test('can override default password field', async () => {
 })
 
 test('allows verifying two password strings', async () => {
-  expect(await Dog.verifyPassword('test', 'test')).toBeTruthy()
+  expect(await verifyPassword('test', 'test')).toBeTruthy()
 
-  expect(await Dog.verifyPassword('test', 'not-the-same')).toBeFalsy()
+  expect(await verifyPassword('test', 'not-the-same')).toBeFalsy()
+})
+
+test('allows creating password using argon2', async () => {
+  const password = await generatePasswordHash('password')
+  const validPassword = isArgonHash(password)
+  expect(validPassword).toBeTruthy()
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,4 @@
-import ObjectionPassword from '../lib/index'
+import ObjectionPassword, { verifyPassword, generatePasswordHash, isArgonHash } from '../lib/index'
 import Knex from 'knex'
 import { Model } from 'objection'
 
@@ -112,7 +112,13 @@ test('can override default password field', async () => {
 })
 
 test('allows verifying two password strings', async () => {
-  expect(await Dog.verifyPassword('test', 'test')).toBeTruthy()
+  expect(await verifyPassword('test', 'test')).toBeTruthy()
 
-  expect(await Dog.verifyPassword('test', 'not-the-same')).toBeFalsy()
+  expect(await verifyPassword('test', 'not-the-same')).toBeFalsy()
+})
+
+test('allows creating password using argon2', async () => {
+  const password = await generatePasswordHash('password')
+  const validPassword = isArgonHash(password)
+  expect(validPassword).toBeTruthy()
 })


### PR DESCRIPTION
I wanted to use the same package in ``knex seeds`` as ``generatePasswordHash('password')``.Adding ``argon2`` as dependency and creating a ``generatePasswordHash`` and ``verifyPasswordHash`` by my own would've been either led to duplication of work or discarding this package in general. Hence I added support for these feature in this feature.